### PR TITLE
Fix sign issue in parse_rd_rs_rs

### DIFF
--- a/riscemu/instructions/instruction_set.py
+++ b/riscemu/instructions/instruction_set.py
@@ -78,7 +78,7 @@ class InstructionSet(ABC):
         if signed:
             return ins.get_reg(0), \
                    Int32(self.get_reg_content(ins, 1)), \
-                   Int32(ins.get_imm(2))
+                   Int32(self.get_reg_content(ins, 2))
         else:
             return ins.get_reg(0), \
                    UInt32(self.get_reg_content(ins, 1)), \

--- a/riscemu/instructions/instruction_set.py
+++ b/riscemu/instructions/instruction_set.py
@@ -77,8 +77,8 @@ class InstructionSet(ABC):
         ASSERT_LEN(ins.args, 3)
         if signed:
             return ins.get_reg(0), \
-                   self.get_reg_content(ins, 1), \
-                   self.get_reg_content(ins, 2)
+                   Int32(self.get_reg_content(ins, 1)), \
+                   Int32(ins.get_imm(2))
         else:
             return ins.get_reg(0), \
                    UInt32(self.get_reg_content(ins, 1)), \


### PR DESCRIPTION
The `parse_rd_rs_rs` function does not return proper wrapped ints (wrapped in `Int32` or `UInt32`) when `signed=True`. 