### PR TITLE
[WIP] wip tokenizer.parse_arg reorders arguments incorrectly for sw instrction

### DIFF
--- a/examples/store-load.asm
+++ b/examples/store-load.asm
@@ -1,0 +1,17 @@
+; hello-world.asm
+; print "hello world" to stdout and exit
+        .data
+msg:    .ascii "Hello world\n"
+        .text
+        addi    a0, zero, 1             ; print to stdout
+        addi    a1, zero, msg           ; load msg address
+        addi    s0, zero, 2000          ; some address in memory
+        sw      s0, a1, 0               ; store address to stack
+        lw      s1, s0, 0               ; load address from stack
+        addi    a1, s0, 0               ; write address to same register again
+        addi    a2, zero, 12            ; write 12 bytes
+        addi    a7, zero, SCALL_WRITE   ; write syscall code
+        scall
+        addi    a0, zero, 0             ; set exit code to 0
+        addi    a7, zero, SCALL_EXIT    ; exit syscall code
+        scall

--- a/riscemu/instructions/RV32F.py
+++ b/riscemu/instructions/RV32F.py
@@ -561,7 +561,7 @@ class RV32F(InstructionSet):
         :Implementation:
           | f[rd] = M[x[rs1] + sext(offset)][31:0]
         """
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rd_rs_mem_ins(ins)
         self.regs.set_f(rd, self.mmu.read_float(addr))
 
     def instruction_fsw(self, ins: Instruction):
@@ -581,7 +581,7 @@ class RV32F(InstructionSet):
         :Implementation:
           | M[x[rs1] + sext(offset)] = f[rs2][31:0]
         """
-        rs, addr = self.parse_mem_ins(ins)
+        rs, addr = self.parse_rs_rs_mem_ins(ins)
         val = self.regs.get_f(rs)
         self.mmu.write(addr, 4, bytearray(val.bytes))
 

--- a/riscemu/instructions/RV32I.py
+++ b/riscemu/instructions/RV32I.py
@@ -23,35 +23,35 @@ class RV32I(InstructionSet):
     """
 
     def instruction_lb(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rd_rs_mem_ins(ins)
         self.regs.set(rd, Int32.sign_extend(self.mmu.read(addr.unsigned_value, 1), 8))
 
     def instruction_lh(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rd_rs_mem_ins(ins)
         self.regs.set(rd, Int32.sign_extend(self.mmu.read(addr.unsigned_value, 2), 16))
 
     def instruction_lw(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rd_rs_mem_ins(ins)
         self.regs.set(rd, Int32(self.mmu.read(addr.unsigned_value, 4)))
 
     def instruction_lbu(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rd_rs_mem_ins(ins)
         self.regs.set(rd, Int32(self.mmu.read(addr.unsigned_value, 1)))
 
     def instruction_lhu(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rd_rs_mem_ins(ins)
         self.regs.set(rd, Int32(self.mmu.read(addr.unsigned_value, 2)))
 
     def instruction_sb(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rs_rs_mem_ins(ins)
         self.mmu.write(addr.unsigned_value, 1, self.regs.get(rd).to_bytes(1))
 
     def instruction_sh(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rs_rs_mem_ins(ins)
         self.mmu.write(addr.unsigned_value, 2, self.regs.get(rd).to_bytes(2))
 
     def instruction_sw(self, ins: "Instruction"):
-        rd, addr = self.parse_mem_ins(ins)
+        rd, addr = self.parse_rs_rs_mem_ins(ins)
         self.mmu.write(addr.unsigned_value, 4, self.regs.get(rd).to_bytes(4))
 
     def instruction_sll(self, ins: "Instruction"):

--- a/riscemu/priv/PrivRV32I.py
+++ b/riscemu/priv/PrivRV32I.py
@@ -168,8 +168,14 @@ class PrivRV32I(RV32I):
         ASSERT_LEN(ins.args, 3)
         return ins.get_reg(0), ins.get_reg(1), ins.get_imm(2)
 
-    def parse_mem_ins(self, ins: "Instruction") -> Tuple[str, int]:
+    def parse_rd_rs_mem_ins(self, ins: "Instruction") -> Tuple[str, int]:
         ASSERT_LEN(ins.args, 3)
         addr = self.get_reg_content(ins, 1) + ins.get_imm(2)
         reg = ins.get_reg(0)
+        return reg, addr
+
+    def parse_rs_rs_mem_ins(self, ins: "Instruction") -> Tuple[str, int]:
+        ASSERT_LEN(ins.args, 3)
+        addr = self.get_reg_content(ins, 0) + ins.get_imm(2)
+        reg = ins.get_reg(1)
         return reg, addr


### PR DESCRIPTION
Riscemu tokenizer reorders `sw rs2 imm(rs1)`, which is equivalent to `sw rs1 rs2 imm` to `sw rs2 rs1 imm`. I'm not sure how to fix it in an easy way. This branch contains the code trying to change things at the CPU level, before I realised that the swap happens in the parsing.