### PR TITLE
Fix jump instruction with relative offset

### DIFF
--- a/riscemu/instructions/RV32I.py
+++ b/riscemu/instructions/RV32I.py
@@ -197,17 +197,17 @@ class RV32I(InstructionSet):
     # technically deprecated
     def instruction_j(self, ins: "Instruction"):
         ASSERT_LEN(ins.args, 1)
-        addr = ins.get_imm(0)
+        addr = ins.get_imm(0, self.pc)
         self.pc = addr
 
     def instruction_jal(self, ins: "Instruction"):
         reg = "ra"  # default register is ra
         if len(ins.args) == 1:
-            addr = ins.get_imm(0)
+            addr = ins.get_imm(0, self.pc)
         else:
             ASSERT_LEN(ins.args, 2)
             reg = ins.get_reg(0)
-            addr = ins.get_imm(1)
+            addr = ins.get_imm(1, self.pc)
         self.regs.set(reg, Int32(self.pc))
         self.pc = addr
 

--- a/riscemu/types/instruction.py
+++ b/riscemu/types/instruction.py
@@ -7,7 +7,7 @@ class Instruction(ABC):
     args: tuple
 
     @abstractmethod
-    def get_imm(self, num: int) -> int:
+    def get_imm(self, num: int, rel: int = 0) -> int:
         """
         parse and get immediate argument
         """

--- a/riscemu/types/simple_instruction.py
+++ b/riscemu/types/simple_instruction.py
@@ -17,10 +17,10 @@ class SimpleInstruction(Instruction):
         self.args = args
         self.addr = addr
 
-    def get_imm(self, num: int) -> int:
+    def get_imm(self, num: int, rel: int = 0) -> int:
         resolved_label = self.context.resolve_label(self.args[num], self.addr)
         if resolved_label is None:
-            return parse_numeric_argument(self.args[num])
+            return parse_numeric_argument(self.args[num]) + rel
         return resolved_label
 
     def get_imm_reg(self, num: int) -> Tuple[int, str]:


### PR DESCRIPTION
Fix ```j``` and ```jal``` instructions with relative offset.
