### PR TITLE
Immediate Rework

### DIFF
--- a/examples/jump-test.asm
+++ b/examples/jump-test.asm
@@ -1,0 +1,30 @@
+// Example program (c) by Anton Lydike
+// this calculates the fibonacci sequence and stores it in ram
+
+        .data
+fibs:   .space 56
+
+        .text
+main:
+        addi    s1, zero, 0     // storage index
+        addi    s2, zero, 56    // last storage index
+        addi    t0, zero, 1     // t0 = F_{i}
+        addi    t1, zero, 1     // t1 = F_{i+1}
+        j       test
+loop:
+        sw      t0, fibs(s1)    // save
+        add     t2, t1, t0      // t2 = F_{i+2}
+        addi    t0, t1, 0       // t0 = t1
+        addi    t1, t2, 0       // t1 = t2
+        j       0
+        addi    s1, s1, 4       // increment storage pointer
+        blt     s1, s2, loop    // loop as long as we did not reach array length
+        ebreak
+        // exit gracefully
+        addi    a0, zero, 0
+        addi    a7, zero, 93
+        scall                   // exit with code 0
+
+test:
+        addi    t5, zero, 101
+        j       loop

--- a/riscemu/helpers.py
+++ b/riscemu/helpers.py
@@ -7,6 +7,8 @@ SPDX-License-Identifier: MIT
 from math import log10, ceil
 from typing import Iterable, Iterator, TypeVar, Generic, List, Optional
 
+from riscemu.types.immediate import Immediate
+
 from .types import Int32, UInt32
 from .types.exceptions import *
 
@@ -28,6 +30,20 @@ def parse_numeric_argument(arg: str) -> int:
         if arg.lower().startswith("0x"):
             return int(arg, 16)
         return int(arg)
+    except ValueError as ex:
+        raise ParseException(
+            'Invalid immediate argument "{}", maybe missing symbol?'.format(arg),
+            (arg, ex),
+        )
+    
+def parse_numeric_argument_alt(arg: str) -> Immediate:
+    """
+    parse hex or int strings
+    """
+    try:
+        if arg.lower().startswith("0x"):
+            return Immediate(int(arg, 16), 0)
+        return Immediate(int(arg), 0)
     except ValueError as ex:
         raise ParseException(
             'Invalid immediate argument "{}", maybe missing symbol?'.format(arg),

--- a/riscemu/instructions/RV32I.py
+++ b/riscemu/instructions/RV32I.py
@@ -197,8 +197,11 @@ class RV32I(InstructionSet):
     # technically deprecated
     def instruction_j(self, ins: "Instruction"):
         ASSERT_LEN(ins.args, 1)
-        addr = ins.get_imm(0)
-        self.pc = addr
+        imm = ins.get_imm_alt(0)
+        if imm.type == 0:
+            self.pc += imm.value
+        else:
+            self.pc = imm.value
 
     def instruction_jal(self, ins: "Instruction"):
         reg = "ra"  # default register is ra

--- a/riscemu/types/immediate.py
+++ b/riscemu/types/immediate.py
@@ -1,0 +1,17 @@
+from abc import ABC
+from enum import Enum
+
+class ImmediateKind(Enum):
+    integer = 0
+    label = 1
+
+class Immediate(ABC):
+    value: int
+    type: ImmediateKind
+
+    def __init__(self, value, type):
+        self.value = value
+        self.type = type
+
+    
+    

--- a/riscemu/types/simple_instruction.py
+++ b/riscemu/types/simple_instruction.py
@@ -1,7 +1,9 @@
 from typing import Union, Tuple
 
+from riscemu.types.immediate import Immediate
+
 from . import Instruction, T_RelativeAddress, InstructionContext
-from ..helpers import parse_numeric_argument
+from ..helpers import parse_numeric_argument, parse_numeric_argument_alt
 
 
 class SimpleInstruction(Instruction):
@@ -21,6 +23,12 @@ class SimpleInstruction(Instruction):
         resolved_label = self.context.resolve_label(self.args[num], self.addr)
         if resolved_label is None:
             return parse_numeric_argument(self.args[num])
+        return resolved_label
+    
+    def get_imm_alt(self, num: int) -> Immediate:
+        resolved_label = Immediate(self.context.resolve_label(self.args[num], self.addr), 1)
+        if resolved_label.value is None:
+            return parse_numeric_argument_alt(self.args[num])
         return resolved_label
 
     def get_imm_reg(self, num: int) -> Tuple[int, str]:


### PR DESCRIPTION
I have made the first iteration of the immediate rework as we discussed in pull request #34. It is nowhere near being done yet, but just wanted to present the idea to make sure that I'm on the right track. Right now I created an "Immediate" type with "value" and "type" as fields as well as some alternate methods using it (that run in parallel to the original ones) but only for the jump (j) instruction. I have also attached a little test assembly program which is just a modification of fibs.asm to make sure that the changes have the desired effect. Let me know if that's the right way to go and I will proceed to replace all instances of the immediates and labels with the new class and methods.