### PR TITLE
Move to explicit handling of immediate values

### DIFF
--- a/.github/workflows/ci-pytest.yml
+++ b/.github/workflows/ci-pytest.yml
@@ -41,4 +41,4 @@ jobs:
         poetry run pytest -W error
     - name: Test with lit
       run: |
-        poetry run lit -v test/filecheck
+        poetry run lit --timeout=5 -v test/filecheck

--- a/poetry.lock
+++ b/poetry.lock
@@ -282,6 +282,33 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "psutil"
+version = "5.9.5"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "psutil-5.9.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:be8929ce4313f9f8146caad4272f6abb8bf99fc6cf59344a3167ecd74f4f203f"},
+    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ab8ed1a1d77c95453db1ae00a3f9c50227ebd955437bcf2a574ba8adbf6a74d5"},
+    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4aef137f3345082a3d3232187aeb4ac4ef959ba3d7c10c33dd73763fbc063da4"},
+    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ea8518d152174e1249c4f2a1c89e3e6065941df2fa13a1ab45327716a23c2b48"},
+    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:acf2aef9391710afded549ff602b5887d7a2349831ae4c26be7c807c0a39fac4"},
+    {file = "psutil-5.9.5-cp27-none-win32.whl", hash = "sha256:5b9b8cb93f507e8dbaf22af6a2fd0ccbe8244bf30b1baad6b3954e935157ae3f"},
+    {file = "psutil-5.9.5-cp27-none-win_amd64.whl", hash = "sha256:8c5f7c5a052d1d567db4ddd231a9d27a74e8e4a9c3f44b1032762bd7b9fdcd42"},
+    {file = "psutil-5.9.5-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3c6f686f4225553615612f6d9bc21f1c0e305f75d7d8454f9b46e901778e7217"},
+    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a7dd9997128a0d928ed4fb2c2d57e5102bb6089027939f3b722f3a210f9a8da"},
+    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89518112647f1276b03ca97b65cc7f64ca587b1eb0278383017c2a0dcc26cbe4"},
+    {file = "psutil-5.9.5-cp36-abi3-win32.whl", hash = "sha256:104a5cc0e31baa2bcf67900be36acde157756b9c44017b86b2c049f11957887d"},
+    {file = "psutil-5.9.5-cp36-abi3-win_amd64.whl", hash = "sha256:b258c0c1c9d145a1d5ceffab1134441c4c5113b2417fafff7315a917a026c3c9"},
+    {file = "psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c607bb3b57dc779d55e1554846352b4e358c10fff3abf3514a7a6601beebdb30"},
+    {file = "psutil-5.9.5.tar.gz", hash = "sha256:5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c"},
+]
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
+
+[[package]]
 name = "pyelftools"
 version = "0.29"
 description = "Library for analyzing ELF files and DWARF debugging information"
@@ -431,4 +458,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "52c6ac0d4ad940d610fb2df7674277b3f913f00ecc8b9b0a0c70a98b63daac1d"
+content-hash = "f45ae83e9aa1bfe7b1036da1d85cd9124f5f293d926bc20c37fbb97c52a03efa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ riscemu = "riscemu.__main__:main"
 [tool.poetry.dependencies]
 python = "^3.8"
 pyelftools = "^0.29"
+psutil = "^5.9.5"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"

--- a/riscemu/instructions/instruction_set.py
+++ b/riscemu/instructions/instruction_set.py
@@ -7,9 +7,10 @@ SPDX-License-Identifier: MIT
 from typing import Tuple, Callable, Dict
 
 from abc import ABC
+
 from ..CPU import CPU
 from riscemu.types.exceptions import ASSERT_LEN, ASSERT_IN
-from ..types import Instruction, Int32, UInt32
+from ..types import Instruction, Int32, UInt32, Immediate
 
 
 class InstructionSet(ABC):
@@ -49,23 +50,17 @@ class InstructionSet(ABC):
             if member.startswith("instruction_"):
                 yield member[12:].replace("_", "."), getattr(self, member)
 
-    def parse_mem_ins(self, ins: "Instruction") -> Tuple[str, Int32]:
+    def parse_mem_ins(self, ins: "Instruction") -> Tuple[str, UInt32]:
         """
-        parses both rd, rs, imm and rd, imm(rs) argument format and returns (rd, imm+rs1)
+        parses rd, imm(rs) argument format and returns (rd, imm+rs1)
         (so a register and address tuple for memory instructions)
         """
-        if len(ins.args) == 3:
-            # handle rd, rs1, imm
-            rs = self.get_reg_content(ins, 1)
-            imm = ins.get_imm(2)
-        else:
-            # handle rd, imm(rs1)
-            ASSERT_LEN(ins.args, 2)
-            ASSERT_IN("(", ins.args[1])
-            imm, rs_name = ins.get_imm_reg(1)
-            rs = self.regs.get(rs_name)
+        assert len(ins.args) == 3
+        # handle rd, rs1, imm
         rd = ins.get_reg(0)
-        return rd, rs + imm
+        rs = self.get_reg_content(ins, 1).unsigned()
+        imm = ins.get_imm(2)
+        return rd, rs + imm.abs_value.unsigned()
 
     def parse_rd_rs_rs(
         self, ins: "Instruction", signed=True
@@ -90,7 +85,7 @@ class InstructionSet(ABC):
 
     def parse_rd_rs_imm(
         self, ins: "Instruction", signed=True
-    ) -> Tuple[str, Int32, Int32]:
+    ) -> Tuple[str, Int32, Immediate]:
         """
         Assumes the command is in <name> rd, rs, imm format
         Returns the name of rd, the value in rs and the immediate imm
@@ -100,18 +95,18 @@ class InstructionSet(ABC):
             return (
                 ins.get_reg(0),
                 Int32(self.get_reg_content(ins, 1)),
-                Int32(ins.get_imm(2)),
+                ins.get_imm(2),
             )
         else:
             return (
                 ins.get_reg(0),
                 UInt32(self.get_reg_content(ins, 1)),
-                UInt32(ins.get_imm(2)),
+                ins.get_imm(2),
             )
 
     def parse_rs_rs_imm(
         self, ins: "Instruction", signed=True
-    ) -> Tuple[Int32, Int32, Int32]:
+    ) -> Tuple[Int32, Int32, Immediate]:
         """
         Assumes the command is in <name> rs1, rs2, imm format
         Returns the values in rs1, rs2 and the immediate imm
@@ -120,13 +115,13 @@ class InstructionSet(ABC):
             return (
                 Int32(self.get_reg_content(ins, 0)),
                 Int32(self.get_reg_content(ins, 1)),
-                Int32(ins.get_imm(2)),
+                ins.get_imm(2),
             )
         else:
             return (
                 UInt32(self.get_reg_content(ins, 0)),
                 UInt32(self.get_reg_content(ins, 1)),
-                UInt32(ins.get_imm(2)),
+                ins.get_imm(2),
             )
 
     def get_reg_content(self, ins: "Instruction", ind: int) -> Int32:
@@ -136,14 +131,16 @@ class InstructionSet(ABC):
         return self.regs.get(ins.get_reg(ind))
 
     @property
-    def pc(self):
+    def pc(self) -> int:
         """
         shorthand for self.cpu.pc
         """
         return self.cpu.pc
 
     @pc.setter
-    def pc(self, val):
+    def pc(self, val: int | Int32):
+        if isinstance(val, Int32):
+            val = val.unsigned_value
         self.cpu.pc = val
 
     @property

--- a/riscemu/instructions/instruction_set.py
+++ b/riscemu/instructions/instruction_set.py
@@ -4,12 +4,12 @@ RiscEmu (c) 2021 Anton Lydike
 SPDX-License-Identifier: MIT
 """
 
-from typing import Tuple, Callable, Dict
+from typing import Tuple, Callable, Dict, Union
 
 from abc import ABC
 
 from ..CPU import CPU
-from riscemu.types.exceptions import ASSERT_LEN, ASSERT_IN
+from riscemu.types.exceptions import ASSERT_LEN
 from ..types import Instruction, Int32, UInt32, Immediate
 
 
@@ -138,7 +138,7 @@ class InstructionSet(ABC):
         return self.cpu.pc
 
     @pc.setter
-    def pc(self, val: int | Int32):
+    def pc(self, val: Union[int, Int32]):
         if isinstance(val, Int32):
             val = val.unsigned_value
         self.cpu.pc = val

--- a/riscemu/priv/PrivRV32I.py
+++ b/riscemu/priv/PrivRV32I.py
@@ -148,14 +148,14 @@ class PrivRV32I(RV32I):
                 FMT_CPU
                 + "Jumping from 0x{:x} to {} (0x{:x})".format(
                     self.pc,
-                    self.mmu.translate_address(self.pc + addr.abs_value),
-                    self.pc + addr.abs_value,
+                    self.mmu.translate_address(self.pc + addr.pcrel_value),
+                    self.pc + addr.pcrel_value,
                 )
                 + FMT_NONE
             )
             self.regs.dump_reg_a()
         self.regs.set(reg, Int32(self.pc))
-        self.pc += addr.abs_value - 4
+        self.pc += addr.pcrel_value - 4
 
     def instruction_jalr(self, ins: "Instruction"):
         ASSERT_LEN(ins.args, 3)

--- a/riscemu/priv/PrivRV32I.py
+++ b/riscemu/priv/PrivRV32I.py
@@ -75,7 +75,7 @@ class PrivRV32I(RV32I):
         self.cpu.mode = PrivModes(mpp)
         # restore pc
         mepc = self.cpu.csr.get("mepc")
-        self.cpu.pc = (mepc - self.cpu.INS_XLEN).value
+        self.cpu.pc = (mepc - self.cpu.INS_XLEN).abs_value
 
         if self.cpu.conf.verbosity > 0:
             sec = self.mmu.get_sec_containing(mepc.value)
@@ -105,32 +105,32 @@ class PrivRV32I(RV32I):
     def instruction_beq(self, ins: "Instruction"):
         rs1, rs2, dst = self.parse_rs_rs_imm(ins)
         if rs1 == rs2:
-            self.pc += dst.value - 4
+            self.pc += dst.abs_value - 4
 
     def instruction_bne(self, ins: "Instruction"):
         rs1, rs2, dst = self.parse_rs_rs_imm(ins)
         if rs1 != rs2:
-            self.pc += dst.value - 4
+            self.pc += dst.abs_value - 4
 
     def instruction_blt(self, ins: "Instruction"):
         rs1, rs2, dst = self.parse_rs_rs_imm(ins)
         if rs1 < rs2:
-            self.pc += dst.value - 4
+            self.pc += dst.abs_value - 4
 
     def instruction_bge(self, ins: "Instruction"):
         rs1, rs2, dst = self.parse_rs_rs_imm(ins)
         if rs1 >= rs2:
-            self.pc += dst.value - 4
+            self.pc += dst.abs_value - 4
 
     def instruction_bltu(self, ins: "Instruction"):
         rs1, rs2, dst = self.parse_rs_rs_imm(ins, signed=False)
         if rs1 < rs2:
-            self.pc += dst.value - 4
+            self.pc += dst.abs_value - 4
 
     def instruction_bgeu(self, ins: "Instruction"):
         rs1, rs2, dst = self.parse_rs_rs_imm(ins, signed=False)
         if rs1 >= rs2:
-            self.pc += dst.value - 4
+            self.pc += dst.abs_value - 4
 
     # technically deprecated
     def instruction_j(self, ins: "Instruction"):
@@ -147,19 +147,21 @@ class PrivRV32I(RV32I):
             print(
                 FMT_CPU
                 + "Jumping from 0x{:x} to {} (0x{:x})".format(
-                    self.pc, self.mmu.translate_address(self.pc + addr), self.pc + addr
+                    self.pc,
+                    self.mmu.translate_address(self.pc + addr.abs_value),
+                    self.pc + addr.abs_value,
                 )
                 + FMT_NONE
             )
             self.regs.dump_reg_a()
         self.regs.set(reg, Int32(self.pc))
-        self.pc += addr - 4
+        self.pc += addr.abs_value - 4
 
     def instruction_jalr(self, ins: "Instruction"):
         ASSERT_LEN(ins.args, 3)
         rd, rs, imm = self.parse_rd_rs_imm(ins)
         self.regs.set(rd, Int32(self.pc))
-        self.pc = rs.value + imm.value - 4
+        self.pc = rs.value + imm.abs_value - 4
 
     def instruction_sbreak(self, ins: "Instruction"):
         raise LaunchDebuggerException()
@@ -170,6 +172,6 @@ class PrivRV32I(RV32I):
 
     def parse_mem_ins(self, ins: "Instruction") -> Tuple[str, int]:
         ASSERT_LEN(ins.args, 3)
-        addr = self.get_reg_content(ins, 1) + ins.get_imm(2)
+        addr = self.get_reg_content(ins, 1) + ins.get_imm(2).abs_value
         reg = ins.get_reg(0)
         return reg, addr

--- a/riscemu/priv/types.py
+++ b/riscemu/priv/types.py
@@ -18,6 +18,7 @@ from riscemu.types import (
     MemoryFlags,
     T_AbsoluteAddress,
     BinaryDataMemorySection,
+    Immediate,
 )
 
 
@@ -27,11 +28,8 @@ class ElfInstruction(Instruction):
     args: Tuple[int]
     encoded: int
 
-    def get_imm(self, num: int) -> int:
-        return self.args[num]
-
-    def get_imm_reg(self, num: int) -> Tuple[int, int]:
-        return self.args[-1], self.args[-2]
+    def get_imm(self, num: int) -> Immediate:
+        return Immediate(self.args[num], self.args[num])
 
     def get_reg(self, num: int) -> str:
         return RISCV_REGS[self.args[num]]

--- a/riscemu/types/__init__.py
+++ b/riscemu/types/__init__.py
@@ -14,7 +14,7 @@ NUMBER_SYMBOL_PATTERN = re.compile(r"^\d+[fb]$")
 from .flags import MemoryFlags
 from .int32 import UInt32, Int32
 from .float32 import Float32
-from .instruction import Instruction
+from .instruction import Instruction, Immediate
 from .instruction_context import InstructionContext
 from .memory_section import MemorySection
 from .program import Program

--- a/riscemu/types/instruction.py
+++ b/riscemu/types/instruction.py
@@ -1,5 +1,36 @@
 from abc import ABC, abstractmethod
 from typing import Tuple
+from .int32 import Int32
+
+
+class Immediate:
+    """
+    This class solves a problem of ambiguity when interpreting assembly code.
+
+    Let's look at the following four cases (assuming 1b is 16 bytes back):
+     a) beq     a0, a1, 1b      // conditional jump 16 bytes back
+     b) beq     a0, a1, -16     // conditional jump 16 bytes back
+     c) addi    a0, a1, 1b      // subtract (pc - 16) from a1
+     d) addi    a0, a1, -16     // subtract 16 from a1
+
+    We want a and b to behave the same, but c and d not to.
+
+    The Immediate class solves this problem, by giving each instruction two ways of
+    interpreting a given immediate. It can either get the "absolute value" of the
+    immediate, or it's relative value to the PC.
+
+    In this case, the beq instruction would interpret both as PC relative values,
+    while addi would treat them as absolute values.
+    """
+
+    abs_value: Int32
+    pcrel_value: Int32
+
+    __slots__ = ["abs_value", "pcrel_value"]
+
+    def __init__(self, abs_value: int | Int32, pcrel_value: int | Int32):
+        self.abs_value = Int32(abs_value)
+        self.pcrel_value = Int32(pcrel_value)
 
 
 class Instruction(ABC):
@@ -7,16 +38,9 @@ class Instruction(ABC):
     args: tuple
 
     @abstractmethod
-    def get_imm(self, num: int) -> int:
+    def get_imm(self, num: int) -> Immediate:
         """
         parse and get immediate argument
-        """
-        pass
-
-    @abstractmethod
-    def get_imm_reg(self, num: int) -> Tuple[int, str]:
-        """
-        parse and get an argument imm(reg)
         """
         pass
 

--- a/riscemu/types/instruction.py
+++ b/riscemu/types/instruction.py
@@ -28,7 +28,7 @@ class Immediate:
 
     __slots__ = ["abs_value", "pcrel_value"]
 
-    def __init__(self, abs_value: int | Int32, pcrel_value: int | Int32):
+    def __init__(self, abs_value: Union[int, Int32], pcrel_value: Union[int, Int32]):
         self.abs_value = Int32(abs_value)
         self.pcrel_value = Int32(pcrel_value)
 

--- a/riscemu/types/instruction.py
+++ b/riscemu/types/instruction.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Tuple
+from typing import Union
 from .int32 import Int32
 
 

--- a/riscemu/types/instruction_context.py
+++ b/riscemu/types/instruction_context.py
@@ -33,32 +33,25 @@ class InstructionContext:
         self.base_address = 0
         self.global_symbol_dict = dict()
 
-    def resolve_label(
-        self, symbol: str, address_at: Optional[T_RelativeAddress] = None
+    def resolve_numerical_label(
+        self, symbol: str, address_at: int
     ) -> Optional[T_AbsoluteAddress]:
-        if NUMBER_SYMBOL_PATTERN.match(symbol):
-            if address_at is None:
-                raise ParseException(
-                    "Cannot resolve relative symbol {} without an address!".format(
-                        symbol
-                    )
-                )
-
-            direction = symbol[-1]
-            values = self.numbered_labels.get(symbol[:-1], [])
-            if direction == "b":
-                return max(
-                    (addr + self.base_address for addr in values if addr < address_at),
-                    default=None,
-                )
-            else:
-                return min(
-                    (addr + self.base_address for addr in values if addr > address_at),
-                    default=None,
-                )
+        direction = symbol[-1]
+        values = self.numbered_labels.get(symbol[:-1], [])
+        if direction == "b":
+            return max(
+                (addr + self.base_address for addr in values if addr < address_at),
+                default=None,
+            )
         else:
-            # if it's not a local symbol, try the globals
-            if symbol not in self.labels:
-                return self.global_symbol_dict.get(symbol, None)
-            # otherwise return the local symbol
-            return self.labels.get(symbol, None)
+            return min(
+                (addr + self.base_address for addr in values if addr > address_at),
+                default=None,
+            )
+
+    def resolve_label(self, symbol: str) -> Optional[T_AbsoluteAddress]:
+        # if it's not a local symbol, try the globals
+        if symbol not in self.labels:
+            return self.global_symbol_dict.get(symbol, None)
+        # otherwise return the local symbol
+        return self.labels.get(symbol, None)


### PR DESCRIPTION
This PR is an implementation of #34, using the following approach:

Change the `Instruction.get_imm()` to return an `Immediate` that contains both an absolute value, and a pc relative value.

This forces the instruction implementation to explicitly differentiate between interpreting values as either the numerical value, or as a pc-relative address.