### PR TITLE
Allow reading from stdin

### DIFF
--- a/examples/fibs.asm
+++ b/examples/fibs.asm
@@ -5,6 +5,8 @@
 fibs:   .space 56
 
         .text
+// make main global so it can be picked up by the crt0.s
+.globl  main
 main:
         addi    s1, zero, 0     // storage index
         addi    s2, zero, 56    // last storage index

--- a/riscemu/parser.py
+++ b/riscemu/parser.py
@@ -4,7 +4,8 @@ RiscEmu (c) 2021 Anton Lydike
 SPDX-License-Identifier: MIT
 """
 import re
-from typing import Dict, Tuple, Iterable, Callable, List
+from io import IOBase
+from typing import Dict, Tuple, Iterable, Callable, List, TextIO
 
 from .assembler import MemorySectionType, ParseContext, AssemblerDirectives
 from .colors import FMT_PARSE
@@ -108,33 +109,34 @@ def take_arguments(tokens: Peekable[Token]) -> Iterable[str]:
 
 class AssemblyFileLoader(ProgramLoader):
     """
-    This class loads assembly files written by hand. It understands some assembler directives and supports most
-    pseudo instructions. It does very little verification of source correctness.
+    This class loads assembly files written by hand. It understands some assembler
+    directives and supports most pseudo instructions. It does very little verification
+    of source correctness.
 
-    It also supports numbered jump targets and properly supports local and global scope (.globl assembly directive)
+    It also supports numbered jump targets and properly supports local and global scope
+    (globl assembly directive)
 
 
-    The AssemblyFileLoader loads .asm, .S and .s files by default, and acts as a weak fallback to all other filetypes.
+    The AssemblyFileLoader loads .asm and .s files by default, and acts as a weak
+    fallback to all other filetypes.
     """
 
+    is_binary = False
+
+    source: TextIO
+
     def parse(self) -> Program:
-        with open(self.source_path, "r") as f:
+        with self.source as f:
             return parse_tokens(self.filename, tokenize(f))
 
-    def parse_io(self, io: Iterable[str]):
-        return parse_tokens(self.filename, tokenize(io))
-
     @classmethod
-    def can_parse(cls, source_path: str) -> float:
+    def can_parse(cls, source_name: str) -> float:
         """
-
+        Parse a string assembly file.
         It also acts as a weak fallback if no other loaders want to take the file.
-
-        :param source_path: the path to the source file
-        :return:
         """
         # gcc recognizes these line endings as assembly. So we will do too.
-        if source_path.split(".")[-1] in ("asm", "S", "s"):
+        if source_name == "-" or source_name.split(".")[-1].lower() in ("asm", "s"):
             return 1
         return 0.01
 

--- a/riscemu/priv/ElfLoader.py
+++ b/riscemu/priv/ElfLoader.py
@@ -1,3 +1,5 @@
+import os.path
+from io import IOBase, RawIOBase
 from typing import List
 
 from .Exceptions import *
@@ -21,15 +23,19 @@ class ElfBinaryFileLoader(ProgramLoader):
     This loader respects local and global symbols.
     """
 
+    is_binary = True
+
     program: Program
 
-    def __init__(self, source_path: str, options: T_ParserOpts):
-        super().__init__(source_path, options)
+    def __post_init__(self):
         self.program = Program(self.filename)
 
     @classmethod
-    def can_parse(cls, source_path: str) -> float:
-        with open(source_path, "rb") as f:
+    def can_parse(cls, source_name: str) -> float:
+        if source_name == "-" or not os.path.isfile(source_name):
+            return 0
+
+        with open(source_name, "rb") as f:
             if f.read(4) == b"\x7f\x45\x4c\x46":
                 return 1
         return 0
@@ -43,15 +49,7 @@ class ElfBinaryFileLoader(ProgramLoader):
             from elftools.elf.elffile import ELFFile
             from elftools.elf.sections import Section, SymbolTableSection
 
-            with open(self.source_path, "rb") as f:
-                print(
-                    FMT_ELF
-                    + "[ElfLoader] Loading elf executable from: {}".format(
-                        self.source_path
-                    )
-                    + FMT_NONE
-                )
-                self._read_elf(ELFFile(f))
+            self._read_elf(ELFFile(self.source))
         except ImportError as e:
             print(
                 FMT_PARSE

--- a/riscemu/priv/ImageLoader.py
+++ b/riscemu/priv/ImageLoader.py
@@ -3,20 +3,21 @@ Laods a memory image with debug information into memory
 """
 
 import os.path
+from io import IOBase
 from typing import List, Iterable
 
 from .ElfLoader import ElfMemorySection
 from .types import MemoryImageDebugInfos
-from ..assembler import INSTRUCTION_SECTION_NAMES
 from ..colors import FMT_NONE, FMT_PARSE
-from ..helpers import get_section_base_name
 from ..types import MemoryFlags, ProgramLoader, Program, T_ParserOpts
 
 
 class MemoryImageLoader(ProgramLoader):
+    is_binary = True
+
     @classmethod
-    def can_parse(cls, source_path: str) -> float:
-        if source_path.split(".")[-1] == "img":
+    def can_parse(cls, source_name: str) -> float:
+        if source_name.split(".")[-1] == "img":
             return 1
         return 0
 
@@ -32,7 +33,7 @@ class MemoryImageLoader(ProgramLoader):
         with open(self.options.get("debug"), "r") as debug_file:
             debug_info = MemoryImageDebugInfos.load(debug_file.read())
 
-        with open(self.source_path, "rb") as source_file:
+        with self.source as source_file:
             data: bytearray = bytearray(source_file.read())
 
         for name, sections in debug_info.sections.items():
@@ -66,7 +67,7 @@ class MemoryImageLoader(ProgramLoader):
             + FMT_NONE
         )
 
-        with open(self.source_path, "rb") as source_file:
+        with self.source as source_file:
             data: bytes = source_file.read()
 
         p = Program(self.filename)
@@ -78,9 +79,11 @@ class MemoryImageLoader(ProgramLoader):
         return p
 
     @classmethod
-    def instantiate(cls, source_path: str, options: T_ParserOpts) -> "ProgramLoader":
-        if os.path.isfile(source_path + ".dbg"):
+    def instantiate(
+        cls, source_name: str, source: IOBase, options: T_ParserOpts
+    ) -> "ProgramLoader":
+        if os.path.isfile(source_name + ".dbg"):
             return MemoryImageLoader(
-                source_path, dict(**options, debug=source_path + ".dbg")
+                source_name, source, dict(**options, debug=source_name + ".dbg")
             )
-        return MemoryImageLoader(source_path, options)
+        return MemoryImageLoader(source_name, source, options)

--- a/riscemu/riscemu_main.py
+++ b/riscemu/riscemu_main.py
@@ -176,7 +176,7 @@ class RiscemuMain:
         self.input_files.extend(args.files)
 
         # get selected ins sets
-        self.selected_ins_sets += list(
+        self.selected_ins_sets.extend(
             self.available_ins_sets[name]
             for name, selected in args.ins.items()
             if selected

--- a/riscemu/riscemu_main.py
+++ b/riscemu/riscemu_main.py
@@ -4,7 +4,7 @@ import os
 import sys
 from dataclasses import dataclass
 from io import IOBase, RawIOBase, TextIOBase
-from typing import Type, Dict, List, Optional
+from typing import Type, Dict, List, Optional, Union
 
 from riscemu import AssemblyFileLoader, __version__, __copyright__
 from riscemu.colors import FMT_GRAY, FMT_NONE
@@ -17,7 +17,7 @@ from riscemu.CPU import UserModeCPU
 @dataclass
 class RiscemuSource:
     name: str
-    stream: TextIOBase | RawIOBase
+    stream: Union[TextIOBase, RawIOBase]
 
     def get_score_for(self, loader: ProgramLoader) -> float:
         if loader.is_binary:

--- a/riscemu/riscemu_main.py
+++ b/riscemu/riscemu_main.py
@@ -40,7 +40,7 @@ class RiscemuMain:
     cfg: Optional[RunConfig]
     cpu: Optional[CPU]
 
-    input_files: List[str | RiscemuSource]
+    input_files: List[Union[str, RiscemuSource]]
     selected_ins_sets: List[Type[InstructionSet]]
 
     def __init__(self, cfg: Optional[RunConfig] = None):

--- a/riscemu/riscemu_main.py
+++ b/riscemu/riscemu_main.py
@@ -173,7 +173,7 @@ class RiscemuMain:
         self.cfg = self.create_config(args)
 
         # set input files
-        self.input_files += list(args.files)
+        self.input_files.extend(args.files)
 
         # get selected ins sets
         self.selected_ins_sets += list(

--- a/riscemu/riscemu_main.py
+++ b/riscemu/riscemu_main.py
@@ -238,13 +238,17 @@ class RiscemuMain:
                 raise RuntimeError(
                     f"Cannot load {path}! No loader for this file type available."
                 )
-            if path == "-":
+            if isinstance(path, RiscemuSource):
+                stream = path.stream
+                source_name = path.name
+            elif path == "-":
                 stream: IOBase = sys.stdin
-                path = "<stdin>"
+                source_name = "<stdin>"
             else:
+                source_name = path
                 stream: IOBase = open(path, "rb" if bidder.is_binary else "r")
 
-            programs = bidder.instantiate(path, stream, {}).parse()
+            programs = bidder.instantiate(source_name, stream, {}).parse()
             if isinstance(programs, Program):
                 programs = [programs]
             for p in programs:

--- a/riscemu/riscemu_main.py
+++ b/riscemu/riscemu_main.py
@@ -7,6 +7,7 @@ from io import IOBase, RawIOBase, TextIOBase
 from typing import Type, Dict, List, Optional
 
 from riscemu import AssemblyFileLoader, __version__, __copyright__
+from riscemu.colors import FMT_GRAY, FMT_NONE
 from riscemu.types import CPU, ProgramLoader, Program
 from riscemu.instructions import InstructionSet, InstructionSetDict
 from riscemu.config import RunConfig
@@ -234,7 +235,7 @@ class RiscemuMain:
                 if score > max_bid:
                     max_bid = score
                     bidder = loader
-            if score <= 0:
+            if max_bid <= 0:
                 raise RuntimeError(
                     f"Cannot load {path}! No loader for this file type available."
                 )
@@ -253,6 +254,14 @@ class RiscemuMain:
                 programs = [programs]
             for p in programs:
                 self.cpu.mmu.load_program(p)
+            if self.cfg.verbosity > 2:
+                print(
+                    FMT_GRAY
+                    + "[Startup] Loaded {} with loader {}".format(
+                        source_name, bidder.__name__
+                    )
+                    + FMT_NONE
+                )
 
     def run_from_cli(self, argv: List[str]):
         # register everything
@@ -264,6 +273,14 @@ class RiscemuMain:
         self.instantiate_cpu()
         self.load_programs()
 
+        if self.cfg.verbosity > 3:
+            print(
+                FMT_GRAY
+                + "[Startup] Startup complete, the following sections were loaded"
+            )
+            for sec in self.cpu.mmu.sections:
+                print("          {}".format(sec.debug_str()))
+            print(FMT_NONE)
         # run the program
         self.cpu.launch(self.cfg.verbosity > 1)
 

--- a/riscemu/types/memory_section.py
+++ b/riscemu/types/memory_section.py
@@ -171,3 +171,13 @@ class MemorySection(ABC):
             self.flags,
             self.owner,
         )
+
+    def debug_str(self) -> str:
+        return "0x{:08X}-0x{:08X} flags={} {}[{}] ({}bytes)".format(
+            self.base,
+            self.base + self.size,
+            self.flags,
+            self.owner,
+            self.name,
+            self.size,
+        )

--- a/riscemu/types/program_loader.py
+++ b/riscemu/types/program_loader.py
@@ -1,29 +1,38 @@
 import os
 from abc import abstractmethod, ABC
-from typing import Union, Iterator, List
+from typing import Union, Iterator, List, ClassVar
+from io import IOBase
 
 from . import T_ParserOpts, Program
 
 
 class ProgramLoader(ABC):
     """
-    A program loader is always specific to a given source file. It is a place to store all state
-    concerning the parsing and loading of that specific source file, including options.
+    A program loader is always specific to a given source file. It is a place to store
+    all state concerning the parsing and loading of that specific source file, including
+    options.
     """
 
-    def __init__(self, source_path: str, options: T_ParserOpts):
-        self.source_path = source_path
+    is_binary: ClassVar[bool]
+
+    def __init__(self, source_name: str, source: IOBase, options: T_ParserOpts):
+        self.source_name = source_name
+        self.source = source
         self.options = options
-        self.filename = os.path.split(self.source_path)[-1]
+        self.filename = os.path.split(self.source_name)[-1]
+        self.__post_init__()
+
+    def __post_init__(self):
+        pass
 
     @classmethod
     @abstractmethod
-    def can_parse(cls, source_path: str) -> float:
+    def can_parse(cls, source_name: str) -> float:
         """
         Return confidence that the file located at source_path
         should be parsed and loaded by this loader
-        :param source_path: the path of the source file
-        :return: the confidence that this file belongs to this parser
+        :param source_name: the name of the input
+        :return: the confidence that this file belongs to this parser in [0,1]
         """
         pass
 
@@ -39,15 +48,18 @@ class ProgramLoader(ABC):
         pass
 
     @classmethod
-    def instantiate(cls, source_path: str, options: T_ParserOpts) -> "ProgramLoader":
+    def instantiate(
+        cls, source_name: str, source: IOBase, options: T_ParserOpts
+    ) -> "ProgramLoader":
         """
         Instantiate a loader for the given source file with the required arguments
 
-        :param source_path: the path to the source file
-        :param options: the parsed options (guaranteed to come from this classes get_options method.
+        :param source_name: the path to the source file
+        :param source: IO Object representing the source
+        :param options: the parsed options (guaranteed to come from this classes get_options method).
         :return: An instance of a ProgramLoader for the spcified source
         """
-        return cls(source_path, options)
+        return cls(source_name, source, options)
 
     @abstractmethod
     def parse(self) -> Union[Program, Iterator[Program]]:

--- a/test/filecheck/fibs.asm
+++ b/test/filecheck/fibs.asm
@@ -1,8 +1,10 @@
-// RUN: python3 -m riscemu -v -o ignore_exit_code %s | filecheck %s
+// RUN: python3 -m riscemu -v -o ignore_exit_code,libc %s | filecheck %s
 .data
 fibs:   .space 1024
 
 .text
+// make main global so it can be picked up by the crt0.s
+.globl  main
 main:
         addi    s1, zero, 0     // storage index
         addi    s2, zero, 1024  // last storage index


### PR DESCRIPTION
This PR enables riscemu to read from stdin (or any other IO-like source when started programatically).

`cat <file> | riscemu -` lets riscemu read from stdin. Note that input type detection is worsened by this (reading elf files from stdin is not supported currently).

Furthermore, if used programatically, one can add `RiscemuSource` objects to the `input_files` list of a `RiscemuMain` object to add more inputs to the executed program. Each source object has a name and either a RawIO or a TextIO-like object attached to it.